### PR TITLE
fix: Call addEnv before concatenating portable.env

### DIFF
--- a/portable.sh
+++ b/portable.sh
@@ -191,6 +191,17 @@ function importEnv() {
 	genXAuth
 	cat "${_portableConfig}" >"${XDG_DATA_HOME}/${stateDirectory}/portable-generated.env"
 	printf "\n\n" >>"${XDG_DATA_HOME}/${stateDirectory}/portable-generated.env"
+	addEnv "LD_PRELOAD=${LD_PRELOAD}"
+	addEnv 'GDK_DEBUG=portals'
+	addEnv 'GTK_USE_PORTAL=1'
+	addEnv 'QT_AUTO_SCREEN_SCALE_FACTOR=1'
+	addEnv "GTK_IM_MODULE=${GTK_IM_MODULE}"
+	addEnv "QT_IM_MODULE=${QT_IM_MODULE}"
+	addEnv "QT_ENABLE_HIGHDPI_SCALING=1"
+	addEnv "PATH=/sandbox:${PATH}"
+	addEnv "DISPLAY=${DISPLAY}"
+	addEnv "QT_SCALE_FACTOR=${QT_SCALE_FACTOR}"
+	addEnv "PS1='╰─>Portable Sandbox·${appID}·🧐⤔ '"
 	printf "\n\n" >>"${XDG_DATA_HOME}/${stateDirectory}/portable-generated.env"
 	if [ -e "${XDG_DATA_HOME}"/${stateDirectory}/portable.env ]; then
 		pecho info "${XDG_DATA_HOME}/${stateDirectory}/portable.env exists"
@@ -209,17 +220,6 @@ function importEnv() {
 	#else
 	#	export LD_PRELOAD="${LD_PRELOAD} ${PW_V4L2_LD_PRELOAD}"
 	#fi
-	addEnv "LD_PRELOAD=${LD_PRELOAD}"
-	addEnv 'GDK_DEBUG=portals'
-	addEnv 'GTK_USE_PORTAL=1'
-	addEnv 'QT_AUTO_SCREEN_SCALE_FACTOR=1'
-	addEnv "GTK_IM_MODULE=${GTK_IM_MODULE}"
-	addEnv "QT_IM_MODULE=${QT_IM_MODULE}"
-	addEnv "QT_ENABLE_HIGHDPI_SCALING=1"
-	addEnv "PATH=/sandbox:${PATH}"
-	addEnv "DISPLAY=${DISPLAY}"
-	addEnv "QT_SCALE_FACTOR=${QT_SCALE_FACTOR}"
-	addEnv "PS1='╰─>Portable Sandbox·${appID}·🧐⤔ '"
 	echo "source ~/portable-generated.env" >"${XDG_DATA_HOME}"/${stateDirectory}/.bashrc
 }
 


### PR DESCRIPTION
Close #107 