### PR TITLE
Bwrap network isolation

### DIFF
--- a/config
+++ b/config
@@ -30,4 +30,7 @@ gameMode="false"
 # Wake the application using D-Bus calls towards StatusNotifiers.
 dbusWake="false"
 
+# Exposes netowrk and DNS config
+bindNetwork="false"
+
 # Below you can set envs that will be imported into the application sandbox

--- a/portable.sh
+++ b/portable.sh
@@ -383,6 +383,7 @@ function execApp() {
 		--ro-bind-try "${XDG_RUNTIME_DIR}/pulse" \
 			"${XDG_RUNTIME_DIR}/pulse" \
 		${pipewireBinding} \
+		${bwNetArg} \ 
 		--bind "${XDG_RUNTIME_DIR}/doc/by-app/${appID}" \
 			"${XDG_RUNTIME_DIR}"/doc \
 		--ro-bind /dev/null \
@@ -548,6 +549,14 @@ function deviceBinding() {
 		bwInputArg=""
 		pecho debug "Not exposing input devices"
 	fi
+	bwNetArg=""
+	if [[ "${bindNetwork}" = "false" ]]; then
+		pecho debug "Network access disabled via config"
+		bwNetArg="--unshare-net --ro-bind /dev/null /etc/resolv.conf"
+	else
+		pecho debug "Network access allowed"
+	fi
+ 	pecho debug "Generated Network bind parameter: ${bwNetArg}"
 	if [[ ${bindPipewire} = "true" ]]; then
 		pipewireBinding="--ro-bind-try ${XDG_RUNTIME_DIR}/pipewire-0 ${XDG_RUNTIME_DIR}/pipewire-0"
 	fi

--- a/portable.sh
+++ b/portable.sh
@@ -550,7 +550,7 @@ function deviceBinding() {
 		pecho debug "Not exposing input devices"
 	fi
 	bwNetArg=""
-	if [[ "${bindNetwork}" = "false" ]]; then
+	if [[ ${bindNetwork} = "false" ]]; then
 		pecho debug "Network access disabled via config"
 		bwNetArg="--unshare-net --ro-bind /dev/null /etc/resolv.conf"
 	else


### PR DESCRIPTION
I added an option to disable network with bwrap.

Setting this option to false passes `--unshare-net --ro-bind /dev/null /etc/resolv.conf` to the bwrap command that creates a new session.

I tested it with one application and with a test connection to 8.8.8.8 via `telnet 8.8.8.8 53` in the helper.sh file.