### PR TITLE
New home for sandbox & remove XDG_CONFIG_HOME/gtk*

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Portable is a sandbox framework targeted for Desktop usage and offers ease of us
 1. **Running untrusted code is never safe, sandboxing does not change this.**
 2. WebKitGTK on a hybrid graphics laptop may require `gameMode=on`, otherwise may display a blank screen.
 3. Steam will not work due to the requirement of Flatpak spawn portal.
-4. Some applications directly calling the open file portal or `FileManager1` will not be path-translated by portable, resulting in broken open function.
+4. ~~Some applications directly calling the open file portal or `FileManager1` will not be path-translated by portable, resulting in broken open function.~~
 5. On KDE Plasma window grouping may not work properly unless your desktop file name exactly matches certain arguments.
 6. The USB Portal is not fully tested, it may fail on some devices.
 7. Due to some desktop portal implementations being insecure (without requiring user consent), some features will only be available on GNOME

--- a/portable.sh
+++ b/portable.sh
@@ -331,6 +331,7 @@ function execApp() {
 	-p Environment=instanceId="${instanceId}" \
 	-p Environment=busDir=${busDir} \
 	-p "${sdNetArg}" \
+	-p Environment=HOME="${XDG_DATA_HOME}/${stateDirectory}" \
 	-- \
 	bwrap --new-session \
 		--unshare-cgroup-try \

--- a/portable.sh
+++ b/portable.sh
@@ -242,6 +242,21 @@ function getChildPid() {
 	done
 }
 
+# Function used to escape paths for sed processing.
+function pathEscape() {
+	local str="$@"
+	local delimiter="|"
+	# Escape the delimiter and &
+	str="${str//${delimiter}/\\${delimiter}}"
+	str="${str//&/\\&}"
+	echo "$str"
+}
+
+# Translates path based on ~ to state directory
+function pathTranslation() {
+	sed "s|$(pathEscape ${HOME})|$(pathEscape ${XDG_DATA_HOME}/${stateDirectory})|g"
+}
+
 function defineRunPath() {
 	if [ ! -d ${XDG_RUNTIME_DIR}/portable/${appID} ]; then
 		mkdir -p ${XDG_RUNTIME_DIR}/portable/${appID}
@@ -398,22 +413,23 @@ function execApp() {
 			"${XDG_DATA_HOME}/${stateDirectory}" \
 		--ro-bind-try "${XDG_DATA_HOME}"/icons \
 			"${XDG_DATA_HOME}"/icons \
-		--ro-bind-try "${XDG_CONFIG_HOME}"/gtk-4.0 \
-			"${XDG_CONFIG_HOME}"/gtk-4.0 \
-		--ro-bind-try "${XDG_CONFIG_HOME}"/gtk-3.0 \
-			"${XDG_CONFIG_HOME}"/gtk-3.0 \
+		--ro-bind-try "${XDG_DATA_HOME}"/icons \
+			"$(echo "${XDG_DATA_HOME}" | pathTranslation)/icons" \
 		--ro-bind-try "${wayDisplayBind}" \
 				"${wayDisplayBind}" \
 		--ro-bind-try "${XDG_CONFIG_HOME}"/fontconfig \
 			"${XDG_CONFIG_HOME}"/fontconfig \
+		--ro-bind-try "${XDG_CONFIG_HOME}"/fontconfig \
+			"$(echo "${XDG_CONFIG_HOME}" | pathTranslation)/fontconfig" \
 		--ro-bind-try "${XDG_DATA_HOME}/fonts" \
 			"${XDG_DATA_HOME}/fonts" \
+		--ro-bind-try "${XDG_DATA_HOME}/fonts" \
+			"$(echo "${XDG_DATA_HOME}" | pathTranslation)/fonts" \
 		--ro-bind-try "/run/systemd/resolve/stub-resolv.conf" \
 			"/run/systemd/resolve/stub-resolv.conf" \
 		--tmpfs "${HOME}"/options \
 		--bind-try "${bwBindPar}" "${bwBindPar}" \
 		--tmpfs "${XDG_DATA_HOME}/${stateDirectory}"/options \
-		--bind "${XDG_DATA_HOME}/${stateDirectory}" "${XDG_DATA_HOME}/${stateDirectory}" \
 		${bwCamPar} \
 		--setenv XDG_DOCUMENTS_DIR "$HOME/Documents" \
 		--setenv XDG_DATA_HOME "${XDG_DATA_HOME}" \

--- a/portable.sh
+++ b/portable.sh
@@ -394,6 +394,8 @@ function execApp() {
 		--ro-bind "${XDG_RUNTIME_DIR}/.flatpak/${instanceId}" \
 			"${XDG_RUNTIME_DIR}/flatpak-runtime-directory" \
 		--bind "${XDG_DATA_HOME}/${stateDirectory}" "${HOME}" \
+		--bind "${XDG_DATA_HOME}/${stateDirectory}" \
+			"${XDG_DATA_HOME}/${stateDirectory}" \
 		--ro-bind-try "${XDG_DATA_HOME}"/icons \
 			"${XDG_DATA_HOME}"/icons \
 		--ro-bind-try "${XDG_CONFIG_HOME}"/gtk-4.0 \


### PR DESCRIPTION
This allows applications to use FileManager1 directly without path broken.