### PR TITLE
Feat: rework of helper stop logic

### DIFF
--- a/doc/packager/03-desktop-entry.md
+++ b/doc/packager/03-desktop-entry.md
@@ -9,3 +9,5 @@ X-Flatpak-Tags=aTag;
 X-Flatpak=appID;
 X-Flatpak-RenamedFrom=previousName.desktop;
 ```
+
+Notice: If your app is designated as a single-window program, add `SingleMainWindow=true` to the .desktop file.

--- a/doc/packager/04-mpris.md
+++ b/doc/packager/04-mpris.md
@@ -1,5 +1,7 @@
 # MPRIS media control
 
+MPRIS is used by applications to expose their playback state.
+
 ---
 
 Configuration options:

--- a/doc/user/03-multiple-instances.md
+++ b/doc/user/03-multiple-instances.md
@@ -1,0 +1,9 @@
+# Multiple instances in Portable
+
+---
+
+Portable starts the `launchTarget` by default, the executable path defined by package maintainers. It is considered the main application.
+
+When it terminates for any reason, portable checks for any left processes. If true, it then notifies you about this and let you choose between stopping the whole sandbox and let it run freely.
+
+If you choose the latter, the sandbox remains as long as there are processes running in the background. You can view them easily on GNOME via the Background Apps feature, or via `systemctl --user status ${friendlyName}`.

--- a/lib/helper
+++ b/lib/helper
@@ -40,13 +40,13 @@ function askStop() {
 			--title "${friendlyName}" \
 			--icon=background-app-ghost-symbolic \
 			--question \
-			--text="主程序已退出, 停止沙盒?"
+			--text="主程序已退出但有残余进程, 停止沙盒?"
 	else
 		/usr/bin/zenity \
 			--title "${friendlyName}" \
 			--icon=background-app-ghost-symbolic \
 			--question \
-			--text="Main process terminated, stop sandbox?"
+			--text="Main process terminated with leftovers, stop sandbox?"
 	fi
 	if [[ $? -eq 0 ]]; then
 		systemd-notify --stopping

--- a/lib/helper
+++ b/lib/helper
@@ -34,26 +34,7 @@ function stopApp() {
 	return $?
 }
 
-echo "app-started" >/run/startSignal
-
-startLoop &
-#waitForStart
-
-systemd-notify --ready &
-systemd-notify --status="Sandbox startup complete" &
-
-cmd=$1
-shift
-"$cmd" "$@"
-
-if [[ $(ps | wc -l) -le 7 ]]; then
-	echo "No more application running, terminating..."
-	#kill %1
-	echo terminate-now >/run/startSignal
-	exit 0
-else
-	echo "Warning! There're still processes running in the background."
-	systemd-notify --status="Main application exited"
+function askStop() {
 	if [[ "${LANG}" =~ "zh_CN" ]]; then
 		/usr/bin/zenity \
 			--title "${friendlyName}" \
@@ -73,14 +54,42 @@ else
 		stopApp
 	else
 		systemd-notify --status="User denied session termination"
-		echo "User denied termination, staying in background until all process terminates"
-		while true; do
-			sleep 5s
-			if [[ $(ps | wc -l) -le 7 ]]; then
-				echo "Terminating sandbox..."
-				stopApp
-				break
-			fi
-		done
 	fi
+}
+
+echo "app-started" >/run/startSignal
+
+startLoop &
+#waitForStart
+
+systemd-notify --ready &
+systemd-notify --status="Sandbox startup complete" &
+
+cmd=$1
+shift
+"$cmd" "$@"
+
+#sleep 1s
+_procCnt=$(ps | grep -v zenity | wc -l)
+echo "Process count: ${_procCnt}"
+if [[ "${_procCnt}" -le 8 ]]; then
+	echo "No more application running, terminating..."
+	#kill %1
+	echo terminate-now >/run/startSignal
+	exit 0
+else
+	echo "Warning! There're still processes running in the background."
+	systemd-notify --status="Main application exited"
+	echo "Staying in background until all process terminates"
+	askStop &
+	while true; do
+		sleep 5s
+		_procCnt=$(ps | grep -v zenity | wc -l)
+		#echo "Process count: ${_procCnt}"
+		if [[ "${_procCnt}" -le 9 ]]; then
+			echo "Terminating sandbox..."
+			stopApp
+			break
+		fi
+	done
 fi

--- a/lib/helper
+++ b/lib/helper
@@ -54,16 +54,33 @@ if [[ $(ps | wc -l) -le 7 ]]; then
 else
 	echo "Warning! There're still processes running in the background."
 	systemd-notify --status="Main application exited"
-	_state=$(notify-send --expire-time=200000 --wait --action="kill"="Terminate" --action="ignore"="Dismiss" "Application running in background!" "Terminate as required")
-	if [[ ${_state} = "kill" ]]; then
+	if [[ "${LANG}" =~ "zh_CN" ]]; then
+		/usr/bin/zenity \
+			--title "${friendlyName}" \
+			--icon=background-app-ghost-symbolic \
+			--question \
+			--text="主程序已退出, 停止沙盒?"
+	else
+		/usr/bin/zenity \
+			--title "${friendlyName}" \
+			--icon=background-app-ghost-symbolic \
+			--question \
+			--text="Main process terminated, stop sandbox?"
+	fi
+	if [[ $? -eq 0 ]]; then
 		systemd-notify --stopping
 		echo "User opted to kill processes"
 		stopApp
 	else
-		systemd-notify --status="User denied termination, staying in background indefinitely..."
-		echo "User denied termination, staying in background indefinitely..."
+		systemd-notify --status="User denied session termination"
+		echo "User denied termination, staying in background until all process terminates"
 		while true; do
-			sleep 3650d
+			sleep 5s
+			if [[ $(ps | wc -l) -le 7 ]]; then
+				echo "Terminating sandbox..."
+				stopApp
+				break
+			fi
 		done
 	fi
 fi


### PR DESCRIPTION
Potentially fixes #292 

With this patch, portable first no longer incorrectly decide applications are running in the background. Then, a dialouge is shown while we poll process list every 8 seconds to ensure user is aware & we terminate after application exits. 

Tested with aur/wechat, where the built-in quit function is shitty and unreliable.