### PR TITLE
Allow applications to use @resource syscalls

### DIFF
--- a/portable.sh
+++ b/portable.sh
@@ -516,13 +516,12 @@ function execApp() {
 	-p SystemCallFilter=~@debug \
 	-p SystemCallFilter=~@module \
 	-p SystemCallFilter=~@obsolete \
-	-p SystemCallFilter=~@resources \
 	-p SystemCallFilter=~@raw-io \
 	-p SystemCallFilter=~@reboot \
 	-p SystemCallFilter=~@swap \
-	-p SystemCallErrorNumber=EPERM \
+	-p SystemCallErrorNumber=EAGAIN \
 	-p SyslogIdentifier="portable-${appID}" \
-	-p SystemCallLog='@privileged @debug @cpu-emulation @obsolete io_uring_enter io_uring_register io_uring_setup @resource' \
+	-p SystemCallLog='@privileged @debug @cpu-emulation @obsolete io_uring_enter io_uring_register io_uring_setup @resources' \
 	-p SystemCallLog='~@sandbox' \
 	-p PrivateIPC=yes \
 	-p ProtectClock=yes \

--- a/portable.sh
+++ b/portable.sh
@@ -499,7 +499,7 @@ function execApp() {
 	-p NotifyAccess=all \
 	-p TimeoutStartSec=infinity \
 	-p OOMPolicy=stop \
-	-p SecureBits=noroot-locked\
+	-p SecureBits=noroot-locked \
 	-p KillMode=control-group \
 	-p LimitCORE=0 \
 	-p CPUAccounting=yes \
@@ -522,7 +522,7 @@ function execApp() {
 	-p SystemCallFilter=~@swap \
 	-p SystemCallErrorNumber=EPERM \
 	-p SyslogIdentifier="portable-${appID}" \
-	-p SystemCallLog='@privileged @debug @cpu-emulation @obsolete io_uring_enter io_uring_register io_uring_setup' \
+	-p SystemCallLog='@privileged @debug @cpu-emulation @obsolete io_uring_enter io_uring_register io_uring_setup @resource' \
 	-p SystemCallLog='~@sandbox' \
 	-p PrivateIPC=yes \
 	-p ProtectClock=yes \


### PR DESCRIPTION
Potentially problematic, but compositors and important applications should already acquire realtime via RTKit or something.