### PR TITLE
Hack: make beta glycin work

### DIFF
--- a/lib/overlay-usr/flatpak-spawn
+++ b/lib/overlay-usr/flatpak-spawn
@@ -1,8 +1,14 @@
 #!/usr/bin/bash
-	echo "Acting as flatpak-spawn..."
+echo "Acting as flatpak-spawn..."
+while [[ $(echo "$1" | cut -c 1-1) = "-" ]]; do
+	shift
+done
+if [[ $1 = "prlimit" ]]; then
+	shift
 	while [[ $(echo "$1" | cut -c 1-1) = "-" ]]; do
 		shift
 	done
-	echo "Decoded cmdline: $@"
-	echo "$@" >/run/startSignal
-	exit 0
+fi
+echo "Decoded cmdline: $@"
+$@
+exit $?


### PR DESCRIPTION
It calls for flatpak-spawn with prlimit, we hack that.

Better to write a flatpak-spawn compat layer.