### PR TITLE
Introduce godbus and coreos/systemd to replace systemd-run for Bus proxy

### DIFF
--- a/lib/daemon/go.mod
+++ b/lib/daemon/go.mod
@@ -5,9 +5,7 @@ go 1.25.6
 require (
 	github.com/KarpelesLab/reflink v1.0.2
 	github.com/coreos/go-systemd/v22 v22.7.0
+	github.com/godbus/dbus/v5 v5.2.2
 )
 
-require (
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
-	golang.org/x/sys v0.9.0 // indirect
-)
+require golang.org/x/sys v0.27.0 // indirect

--- a/lib/daemon/go.sum
+++ b/lib/daemon/go.sum
@@ -2,7 +2,7 @@ github.com/KarpelesLab/reflink v1.0.2 h1:hQ1aM3TmjU2kTNUx5p/HaobDoADYk+a6AuEinG4
 github.com/KarpelesLab/reflink v1.0.2/go.mod h1:WGkTOKNjd1FsJKBw3mu4JvrPEDJyJJ+JPtxBkbPoCok=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
-golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
systemd is nasty, the manual page **Clearly** do not have property "StandardErrorFile" yet it exists in the source code. Better yet, StandardError expects file/fd/whatever type, not file:/path you normally invoke sd-run with and write in the unit file, what an undocumented treasure.

ref: "StandardErrorFile" https://man.archlinux.org/man/org.freedesktop.systemd1.5