### PR TITLE
remove configuration key config.system.globalShortcuts

### DIFF
--- a/lib/daemon/confDef.go
+++ b/lib/daemon/confDef.go
@@ -37,7 +37,6 @@ type ProcMgmt struct {
 type SysMgmt struct {
 	InhibitSuspend	bool
 	InhibitOnBehalf	bool
-	GlobalShortcuts	bool
 	GameMode	bool
 }
 

--- a/lib/daemon/daemon.go
+++ b/lib/daemon/daemon.go
@@ -605,6 +605,7 @@ func calcDbusArg(argChan chan []string, config Config) {
 		"--call=org.freedesktop.portal.Desktop=org.freedesktop.portal.Trash.*@/org/freedesktop/portal/desktop",
 		"--call=org.freedesktop.portal.Desktop=org.freedesktop.portal.Usb.*@/org/freedesktop/portal/desktop",
 		"--call=org.freedesktop.portal.Desktop=org.freedesktop.portal.Wallpaper.*@/org/freedesktop/portal/desktop",
+		"--call=org.freedesktop.portal.Desktop=org.freedesktop.portal.GlobalShortcuts.*@/org/freedesktop/portal/desktop",
 
 		"--call=org.freedesktop.portal.Desktop=org.freedesktop.DBus.Properties.*@/org/freedesktop/portal/desktop/*",
 
@@ -696,13 +697,6 @@ func calcDbusArg(argChan chan []string, config Config) {
 		argList = append(
 			argList,
 			"--call=org.freedesktop.portal.Desktop=org.freedesktop.portal.Inhibit.*@/org/freedesktop/portal/desktop",
-		)
-	}
-
-	if config.System.GlobalShortcuts {
-		argList = append(
-			argList,
-			"--call=org.freedesktop.portal.Desktop=org.freedesktop.portal.GlobalShortcuts.*@/org/freedesktop/portal/desktop",
 		)
 	}
 

--- a/lib/daemon/legacyConf.go
+++ b/lib/daemon/legacyConf.go
@@ -58,7 +58,6 @@ func readLegacyConf() Config {
 		bindPipewire		bool
 		bindInputDevices	bool
 		allowInhibit		bool
-		allowGlobalShortcuts	bool
 		allowKDEStatus		bool
 		dbusWake		bool
 		mountInfo		bool
@@ -92,7 +91,6 @@ func readLegacyConf() Config {
 		"bindPipewire":		{b: &legacyConf.bindPipewire},
 		"bindInputDevices":	{b: &legacyConf.bindInputDevices},
 		"allowInhibit":		{b: &legacyConf.allowInhibit},
-		"allowGlobalShortcuts":	{b: &legacyConf.allowGlobalShortcuts},
 		"allowKDEStatus":	{b: &legacyConf.allowKDEStatus},
 		"dbusWake":		{b: &legacyConf.dbusWake},
 		"mountInfo":		{b: &legacyConf.mountInfo},
@@ -117,7 +115,6 @@ func readLegacyConf() Config {
 		"bindPipewire":		"bool",
 		"bindInputDevices":	"bool",
 		"allowInhibit":		"bool",
-		"allowGlobalShortcuts":	"bool",
 		"allowKDEStatus":	"bool",
 		"dbusWake":		"bool",
 		"mountInfo":		"bool",
@@ -215,9 +212,6 @@ func readLegacyConf() Config {
 
 	if legacyConf.gameMode {
 		config.System.GameMode = true
-	}
-	if legacyConf.allowGlobalShortcuts {
-		config.System.GlobalShortcuts = true
 	}
 	if legacyConf.allowInhibit {
 		config.System.InhibitSuspend = true


### PR DESCRIPTION
This allows apps to request shortcut registration and the Portal impls will take permission control themselves.