### PR TITLE
allow the exposure of kdeglobals

### DIFF
--- a/lib/daemon/daemon.go
+++ b/lib/daemon/daemon.go
@@ -1831,6 +1831,17 @@ func miscBinds(miscChan chan []string, pwChan chan []string, config Config, expo
 	wg.Go(func() {
 		miscChan <- []string{
 			"--ro-bind-try",
+			filepath.Join(xdgDir.confDir, "kdeglobals"),
+			translatePath(
+				filepath.Join(xdgDir.confDir, "kdeglobals"),
+				config,
+			),
+		}
+	})
+
+	wg.Go(func() {
+		miscChan <- []string{
+			"--ro-bind-try",
 			xdgDir.confDir + "/qt6ct",
 			translatePath(xdgDir.confDir + "/qt6ct", config),
 		}


### PR DESCRIPTION
this file is required for KDE theming to work, and seems mostly harmless