### PR TITLE
daemon: set OOMPolicy to kill

### DIFF
--- a/lib/daemon/daemon.go
+++ b/lib/daemon/daemon.go
@@ -1310,6 +1310,7 @@ func genBwArg(
 		"-p", "MemoryHigh=90%",
 		"-p", "IPAccounting=yes",
 		"-p", "MemoryPressureWatch=yes",
+		"-p", "OOMPolicy=kill",
 		"-p", "SyslogIdentifier=portable-" + config.Metadata.AppID,
 		"-p", "SystemCallLog=@privileged @debug @cpu-emulation @obsolete io_uring_enter io_uring_register io_uring_setup @resources",
 		"-p", "SystemCallLog=~@sandbox",


### PR DESCRIPTION
This ensures apps get killed before OOM daemons target other system components