### PR TITLE
GPU: detectCardBrand: detect AMD

### DIFF
--- a/lib/daemon/gpu.go
+++ b/lib/daemon/gpu.go
@@ -32,6 +32,8 @@ func detectCardBrand(dev *udev.Device) (gpuBrand, error) {
 			return "intel", nil
 		case "0x10de":
 			return "nvidia", nil
+		case "0x1022":
+			return "amd", nil
 		default:
 			return "unknown", errors.New("Unrecognised vendor " + strconv.Quote(vendor))
 	}


### PR DESCRIPTION
We don't have any AMD powered device there, it's just from the PCI ID repo