### PR TITLE
daemon: mount /proc/filesystems and /proc/mounts to workaround "clever" impls

### DIFF
--- a/lib/daemon/daemon.go
+++ b/lib/daemon/daemon.go
@@ -1458,9 +1458,7 @@ func genBwArg(
 		"--ro-bind-try",	"/dev/null", "/proc/diskstats",
 		"--ro-bind-try",	"/dev/null", "/proc/devices",
 		"--ro-bind-try",	"/dev/null", "/proc/config.gz",
-		"--ro-bind-try",	"/dev/null", "/proc/mounts",
 		"--ro-bind-try",	"/dev/null", "/proc/loadavg",
-		"--ro-bind-try",	"/dev/null", "/proc/filesystems",
 
 		// FHS dir
 		"--perms",		"0000",


### PR DESCRIPTION
https://github.com/Open-Wine-Components/umu-launcher/blob/b76d0165d6196c3ef9d131d0f713da786f85eebb/umu/umu_util.py#L303