### PR TITLE
GPU: handle unknown connector status gracefully instead of panicking

### DIFF
--- a/lib/gpu/isActive.go
+++ b/lib/gpu/isActive.go
@@ -33,7 +33,7 @@ func ListActiveGraphicsCards() ([]*udev.Device, error) {
 				case "disconnected":
 					isConnected = false
 				default:
-					panic("Unknown connector status: " + connectStat + " for connector: " + device.Syspath())
+					isConnected = false
 			}
 			if isConnected {
 				connectorChan <- device


### PR DESCRIPTION
## Problem

Portable panics on startup when a DRM connector reports an unrecognized status. On systems with AMD GPUs (e.g. Radeon 780M), the amdgpu driver exposes a virtual `card*-Writeback-1` connector whose status is `unknown`. The `ListActiveGraphicsCards()` function in `lib/gpu/isActive.go` hits the `default` branch and panics, crashing portable before the sandbox can start.

```
panic: Unknown connector status: unknown for connector: /sys/devices/.../drm/card1/card1-Writeback-1
```

## Fix

Replace the `panic` in the `default` case with `isConnected = false`. Unknown connector status is treated as inactive (not connected), which is the safe default — the function's purpose is to find GPUs with active display connections, and an unknown status should not crash the process.

## Impact

- `connected` → unchanged (active)
- `disconnected` → unchanged (inactive)
- `unknown` / any other value → was: panic crash; now: treated as inactive
