### PR TITLE
GPU: bind the parent device

### DIFF
--- a/src/bind/subsystems/devices.rs
+++ b/src/bind/subsystems/devices.rs
@@ -224,7 +224,7 @@ fn bind_devlinks(devlinks: Option<&std::ffi::OsStr>)
 	ret
 }
 
-async fn bind_udev_device(device: udev::Device) -> Vec<crate::bind::types::BindRule> {
+async fn bind_udev_device(device: &udev::Device) -> Vec<crate::bind::types::BindRule> {
 	use crate::bind::types::BindType;
 	use crate::bind::types::BindRule;
 
@@ -253,12 +253,10 @@ async fn bind_udev_device(device: udev::Device) -> Vec<crate::bind::types::BindR
 
 	{
 		let devpath = std::path::PathBuf::from(device.syspath());
-		let path = std::path::PathBuf::from("/sys");
-		let path = path.join(devpath);
 		ret.push(
 			BindRule::Path {
-				source: path.clone(),
-				dest: path,
+				source: devpath.to_path_buf(),
+				dest: devpath.to_path_buf(),
 				class: BindType::Device,
 			},
 		);

--- a/src/bind/subsystems/devices/camera.rs
+++ b/src/bind/subsystems/devices/camera.rs
@@ -20,7 +20,7 @@ pub async fn scan() -> Result<BindRules, CameraError> {
 
 	for dev in devices {
 		ret.extend(
-			super::bind_udev_device(dev).await
+			super::bind_udev_device(&dev).await
 		);
 	};
 

--- a/src/bind/subsystems/devices/gpu/bind.rs
+++ b/src/bind/subsystems/devices/gpu/bind.rs
@@ -102,14 +102,26 @@ pub async fn generate_bind_rules(
 	};
 
 	ret.extend(
-		crate::bind::subsystems::devices::bind_udev_device(gpu.nodes.card_node)
+		crate::bind::subsystems::devices::bind_udev_device(&gpu.nodes.card_node)
 			.await
 	);
 
 	ret.extend(
-		crate::bind::subsystems::devices::bind_udev_device(gpu.nodes.render_node)
+		crate::bind::subsystems::devices::bind_udev_device(&gpu.nodes.render_node)
 			.await
 	);
+
+	match &gpu.nodes.card_node.parent() {
+		Some(v)	=> {
+			ret.extend(
+				crate::bind::subsystems::devices::bind_udev_device(&v)
+					.await
+			);
+		}
+		None	=> {}
+	}
+
+
 
 	ret
 }

--- a/src/bind/subsystems/devices/input.rs
+++ b/src/bind/subsystems/devices/input.rs
@@ -64,7 +64,7 @@ pub async fn scan() -> Result<crate::bind::types::BindRules, InputError> {
 	};
 
 	for device in devices {
-		ret.extend(super::bind_udev_device(device).await);
+		ret.extend(super::bind_udev_device(&device).await);
 	};
 
 	Ok(crate::bind::types::DeDupRules::dedup(ret))


### PR DESCRIPTION
Parent device is used to register as a driver, and exposes uevents that udev needs