### PR TITLE
bus: mount a compatibility D-Bus socket at /run/sessionBus

### DIFF
--- a/src/bind/bus/proxies/session/address.rs
+++ b/src/bind/bus/proxies/session/address.rs
@@ -28,11 +28,17 @@ pub async fn get_address_with_sandbox(
 
 		let host_sandbox = vec![
 			crate::bind::types::BindRule::Path {
-				source: proxy_parent_path,
+				source: proxy_parent_path.to_path_buf(),
 				dest: "/run/session_bus".into(),
 				class: crate::bind::types::BindType::ReadOnly,
+			},
+			crate::bind::types::BindRule::Symlink {
+				source:	"/run/session_bus/bus".into(),
+				dest:	"/run/sessionBus".into(),
 			}
 		];
+
+
 
 		Ok((proxy_socket, host_sandbox))
 }

--- a/src/bind/types.rs
+++ b/src/bind/types.rs
@@ -17,6 +17,10 @@ pub enum BindRule {
 		dest:		std::path::PathBuf,
 		class:		BindType,
 	},
+
+	/**
+		Create a symlink at DEST with target SRC
+	*/
 	Symlink {
 		source:		std::path::PathBuf,
 		dest:		std::path::PathBuf,


### PR DESCRIPTION
This is currently used by Steam to fake a system bus, and we don't want to break apps