### PR TITLE
unify environment forwarding

### DIFF
--- a/src/envs.rs
+++ b/src/envs.rs
@@ -1,1 +1,3 @@
 pub mod holder;
+
+pub mod forward;

--- a/src/envs/forward.rs
+++ b/src/envs/forward.rs
@@ -11,14 +11,9 @@ pub fn get() -> std::collections::HashMap<String, String> {
 	];
 
 	for env in envs {
-		match std::env::var(env) {
+		match std::env::var(&env) {
 			Ok(v)	=> {
-				match v.split_once("=") {
-					Some((k, v))	=> {
-						map.insert(k.into(), v.into());
-					}
-					None		=> {}
-				}
+				map.insert(env.into(), v.into());
 			}
 			Err(_)	=> {}
 		}

--- a/src/envs/holder.rs
+++ b/src/envs/holder.rs
@@ -29,29 +29,9 @@ pub async fn holder(
 	mut rx: HoldChannelRx,
 	log_tx: crate::logger::LogSender,
 ) {
-	use std::collections::HashMap;
 	use crate::logger::LogMessage;
 
-	let mut envs_map: HashMap<String, String> = HashMap::new();
-
-	match std::env::var("XDG_ACTIVATION_TOKEN") {
-		Ok(v)	=> {
-			match v.split_once("=") {
-				Some((k, v))	=> {
-					envs_map.insert(k.into(), v.into());
-				}
-				None		=> {}
-			}
-		}
-		Err(e)	=> {
-			let _ = log_tx.send(
-				LogMessage {
-					level: crate::logger::LogLevel::Warn,
-					message: format!("Could not forward XDG_ACTIVATION_TOKEN: {e:#?}"),
-				}
-			).await;
-		}
-	};
+	let mut envs_map = super::forward::get();
 
 	loop {
 		let msg = tokio::select! {

--- a/src/ipc/init/aux_start.rs
+++ b/src/ipc/init/aux_start.rs
@@ -1,5 +1,3 @@
-mod envs;
-
 #[zbus::proxy(
 	interface	= "top.kimiblock.Portable.Init",
 	default_path	= "/top/kimiblock/portable/init",
@@ -73,13 +71,23 @@ pub async fn start(
 		.await
 	};
 
+	let env_var = crate::envs::forward::get();
+
+	#[cfg(debug_assertions)]
+	let _ = logger.send(
+		crate::logger::LogMessage {
+			level:		crate::logger::LogLevel::Debug,
+			message: format!("Forawrding variables: {env_var:#?}"),
+		}
+	).await;
+
 	proxy.request_start(
 		true,
 		exec,
 		false,
 		args,
 		forward_map,
-		envs::get(),
+		env_var,
 		crate::spawn::stream::setup(logger, stop_func, stop_tx)
 			.await
 			.map_err(AuxStartError::ConsoleError)

--- a/src/spawn/stream.rs
+++ b/src/spawn/stream.rs
@@ -86,7 +86,7 @@ async fn stream_in(file: std::fs::File) -> Result<(), StreamError> {
 	nix::ioctl_write_ptr_bad!(ioctl_set_winsize, nix::libc::TIOCSWINSZ, nix::libc::winsize);
 
 
-	let mut buffer = [0u8, 255];
+	let mut buffer = [0u8; 1024];
 	let mut stdin = {
 		use std::os::fd::AsFd;
 		let stdin = std::io::stdin()
@@ -158,7 +158,7 @@ async fn stream_in(file: std::fs::File) -> Result<(), StreamError> {
 }
 
 async fn stream_out(file: std::fs::File) -> Result<(), StreamError> {
-	let mut buffer = [0u8, 255];
+	let mut buffer = [0u8; 1024];
 	let mut stdout = std::io::stdout();
 	let mut tokio_file = tokio::fs::File::from_std(file);
 	use tokio::io::AsyncReadExt;


### PR DESCRIPTION
Also fixes an oversight: std::env::var returns the variable key directly, so we should not split with = here