### PR TITLE
a11y: disable the SEE policy for a11y service

### DIFF
--- a/src/bind/bus/proxies/session.rs
+++ b/src/bind/bus/proxies/session.rs
@@ -156,11 +156,6 @@ async fn generate_bus_rules(
 				.map_err(ProxyError::InvalidBusNameError)
 				?,
 		},
-		BusAccessLevel::See {
-			bus_name: BusName::try_from("org.a11y.Bus")
-				.map_err(ProxyError::InvalidBusNameError)
-				?,
-		},
 
 		BusAccessLevel::Call {
 			bus_name: BusName::try_from("org.a11y.Bus")


### PR DESCRIPTION
Does not undermine screen reader