### PR TITLE
config: remove the version directive

### DIFF
--- a/src/pref/config/config_definition.rs
+++ b/src/pref/config/config_definition.rs
@@ -42,12 +42,7 @@ pub struct Metadata {
 	pub display_name:	String,
 	#[serde(alias = "stateDirectory")]
 	pub state_directory:	String,
-
-	#[serde(default = "default_config_version")]
-	pub config_version:	usize,
 }
-
-fn default_config_version () -> usize {0}
 
 #[derive(Debug, Deserialize)]
 pub struct Exec {

--- a/src/pref/config/config_legacy.rs
+++ b/src/pref/config/config_legacy.rs
@@ -55,7 +55,6 @@ pub async fn get_legacy_conf(path: &std::path::Path) -> Result<Config, LegacyCon
 			sandbox_id: decoded_legacy_conf.app_id,
 			display_name: decoded_legacy_conf.friendly_name,
 			state_directory: decoded_legacy_conf.state_dir,
-			config_version: 10,
 		},
 		exec: Exec {
 			target: decoded_legacy_conf.target.0,


### PR DESCRIPTION
We don't intend to break compatibility often