### PR TITLE
user subsystem: try to set the XCURSOR environment variable

### DIFF
--- a/src/bind/subsystems.rs
+++ b/src/bind/subsystems.rs
@@ -178,6 +178,9 @@ pub async fn generate_bindrules(
 			translator:	translator,
 			xdg:		xdg.clone(),
 			config:		config.clone(),
+			bus:		dbus_conn.clone(),
+			env:		env.clone(),
+			logger:		logger.clone(),
 		};
 		workers.push(
 			tokio::spawn(

--- a/src/bind/subsystems/user.rs
+++ b/src/bind/subsystems/user.rs
@@ -18,11 +18,22 @@ pub struct UserBind {
 	pub translator:	crate::bind::translate::Delta,
 	pub xdg:	std::sync::Arc<crate::xdg::XdgDirs>,
 	pub config:	std::sync::Arc<crate::config::config_definition::Config>,
+	pub env:	crate::envs::holder::HoldChannel,
+	pub logger:	crate::logger::LogSender,
+	pub bus:	zbus::Connection,
 }
 
 
 impl super::GenerateBind for UserBind {
 	async fn bind(self) -> Result<crate::bind::types::BindRules, Self::BindError> {
+		let xcursor_spawn = tokio::spawn(
+			theming::xcursor::forward_xcursor(
+				self.env,
+				self.logger,
+				self.bus,
+			)
+		);
+
 		let mut binds = paths::bind(
 			self.xdg.data_home.to_path_buf(),
 			&self.config.metadata.state_directory,
@@ -35,6 +46,12 @@ impl super::GenerateBind for UserBind {
 				self.xdg.data_home.to_path_buf(),
 			).await?,
 		);
+
+		xcursor_spawn
+			.await
+			.map_err(UserBindError::TokioSpawnError)
+			?
+			?;
 
 		Ok(binds)
 	}
@@ -55,4 +72,13 @@ pub enum UserBindError {
 
 	#[error("Error spawning Zenity: {0:#?}")]
 	ZenitySpawnError(std::io::Error),
+
+	#[error("Error spawning tokio thread: {0:#?}")]
+	TokioSpawnError(tokio::task::JoinError),
+
+	#[error("Error forwarding environment variable: {0:#?}")]
+	ForwardEnvsError(tokio::sync::mpsc::error::SendError<crate::envs::holder::EnvMessage>),
+
+	#[error("Error converting obtained cursor variant to String: {0:#?}")]
+	CursorVariantStringError(zbus::zvariant::Error),
 }

--- a/src/bind/subsystems/user/theming.rs
+++ b/src/bind/subsystems/user/theming.rs
@@ -1,3 +1,5 @@
+pub mod xcursor;
+
 pub async fn bind(
 	translator:	crate::bind::translate::Delta,
 	xdg_config:	std::path::PathBuf,

--- a/src/bind/subsystems/user/theming/xcursor.rs
+++ b/src/bind/subsystems/user/theming/xcursor.rs
@@ -1,0 +1,53 @@
+/**
+	Read the current cursor theme from Portal if able, and send the envs over to channel
+
+	The specific way of choice is querying the Settings Portal for "cursor-theme" under
+		namespace "org.gnome.desktop.interface".
+*/
+pub async fn forward_xcursor(
+	env:		crate::envs::holder::HoldChannel,
+	logger:		crate::logger::LogSender,
+	bus:		zbus::Connection,
+) -> Result<(), crate::bind::subsystems::user::UserBindError> {
+	let cursor_name = {
+		let raw_value = match crate::ipc::portals::settings::read_one(
+			&bus,
+			"org.gnome.desktop.interface",
+			"cursor-theme",
+		).await {
+			Ok(v)	=> v,
+			Err(e)	=> {
+				let _ = logger.send(
+					crate::logger::LogMessage {
+						level:		crate::logger::LogLevel::Warn,
+						message:	format!("Could not retrieve cursor theme from Portal: {e:#?}"),
+					}
+				).await;
+				return Ok(());
+			}
+		};
+
+		match String::try_from(raw_value) {
+			Ok(v)	=> v,
+			Err(e)	=> {
+				return Err(
+					crate::bind::subsystems::user::UserBindError::CursorVariantStringError(e)
+				);
+			}
+		}
+	};
+
+	env.send(
+		crate::envs::holder::EnvMessage::Add {
+			key:	"XCURSOR_THEME".into(),
+			value:	cursor_name,
+		}
+	)
+		.await
+		.map_err(crate::bind::subsystems::user::UserBindError::ForwardEnvsError)
+		?;
+
+	Ok(())
+}
+
+


### PR DESCRIPTION
It querys for the cursor-name key under GNOME interface namespace, and translates that into XCURSOR_THEME variable

This will not override user preference set in portable.env, as it happens later than initial loading