### PR TITLE
fix job termination on KDE Plasma

### DIFF
--- a/src/bind/bus/proxies/session.rs
+++ b/src/bind/bus/proxies/session.rs
@@ -519,7 +519,7 @@ async fn generate_bus_rules(
 				bus_name: BusName::try_from("org.kde.JobViewServer")
 					.map_err(ProxyError::InvalidBusNameError)
 					?,
-				method: "org.kde.JobViewServer=org.kde.JobViewV3.terminate".into(),
+				method: "org.kde.JobViewV3.terminate".into(),
 				object_path: "/org/kde/notificationmanager/jobs/*".into(),
 			}
 		);


### PR DESCRIPTION
While porting a specific D-Bus rule, we forgot to remove the D-Bus well-known name from method