### PR TITLE
user envs: a few fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Chromium-based application will now work with full lockdown hardening with their internal sandbox.
 - Fixed a bug causing Portable to not recognise `wp_security_context_manager_v1` on KWin and Niri
 - XCURSOR_THEME is now set accordingly for legacy applications not utilising the cursor shape protocol
+- Fixed warnings regarding empty lines in `portable.env`
 
 ## Internal Changes
 ### Daemon
@@ -20,6 +21,7 @@
 * session bus: further sandbox the Fcitx portal by @Kimiblock in https://github.com/Kraftland/portable/pull/1288
 * display subsystem: simplify Wayland security context by @Kimiblock in https://github.com/Kraftland/portable/pull/1291
 * get_address_with_sandbox: guard bus parent behind debug logging in https://github.com/Kraftland/portable/pull/1293
+* user envs: a few fixes in https://github.com/Kraftland/portable/pull/1294
 
 ### Init
 * seccomp: allow capset by @Kimiblock in https://github.com/Kraftland/portable-init/pull/76

--- a/src/envs/user.rs
+++ b/src/envs/user.rs
@@ -72,9 +72,11 @@ pub async fn load_user_envs(
 		let line = line.trim();
 		if line.starts_with("#") {
 			continue;
+		} else if line.is_empty() {
+			continue;
 		};
 
-		match line.trim().split_once("=") {
+		match line.split_once("=") {
 			Some((k, v))	=> {
 				map.insert(k.to_string(), v.to_string());
 			}


### PR DESCRIPTION
1. Don't trim twice to save computing power
2. Skip empty lines instead of printing a warning